### PR TITLE
Fix deprecation of global flags in regexpes

### DIFF
--- a/src/wikiextractor/extract.py
+++ b/src/wikiextractor/extract.py
@@ -376,11 +376,11 @@ wgUrlProtocols = [
 # as well as U+3000 is IDEOGRAPHIC SPACE for bug 19052
 EXT_LINK_URL_CLASS = r'[^][<>"\x00-\x20\x7F\s]'
 ExtLinkBracketedRegex = re.compile(
-    '\[(((?i)' + '|'.join(wgUrlProtocols) + ')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
+        '\[((?i:' + '|'.join(wgUrlProtocols) + ')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
     re.S | re.U)
 EXT_IMAGE_REGEX = re.compile(
     r"""^(http://|https://)([^][<>"\x00-\x20\x7F\s]+)
-    /([A-Za-z0-9_.,~%\-+&;#*?!=()@\x80-\xFF]+)\.((?i)gif|png|jpg|jpeg)$""",
+    /([A-Za-z0-9_.,~%\-+&;#*?!=()@\x80-\xFF]+)\.(?i:gif|png|jpg|jpeg)$""",
     re.X | re.S | re.U)
 
 
@@ -392,7 +392,7 @@ def replaceExternalLinks(text):
         cur = m.end()
 
         url = m.group(1)
-        label = m.group(3)
+        label = m.group(2)
 
         # # The characters '<' and '>' (which were escaped by
         # # removeHTMLtags()) should not be included in


### PR DESCRIPTION
A few regular expressions in the wikiextractor seems to use global flags in a way that has been deprecated sinve Python 3.9 and removed in Python 3.11.